### PR TITLE
개인사용용도로 수정되었던 일부 코드 수정

### DIFF
--- a/singleMap/js/index.js
+++ b/singleMap/js/index.js
@@ -177,7 +177,7 @@ function getIconInfo(Name) {
 		case "ST": { //神瞳
 			var icon_base = L.Icon.extend({
 				options: {
-					iconSize: [40, 40], // size of the icon
+					iconSize: [24, 24], // size of the icon
 					shadowSize: [50, 64], // size of the shadow
 					iconAnchor: [12, 12], // point of the icon which will correspond to marker's location
 					shadowAnchor: [4, 62], // the same for the shadow
@@ -450,7 +450,7 @@ function MarkPoint(element) {
 
 	var doneUrl = newValue ? "_done" : ""
 	if (layerNumber == 0 || layerNumber == 1) {
-		var iconUrl = "./imgs/icon_" + layerNumber + doneUrl + ".png";
+		var iconUrl = "./imgs/icon_" + layerNumber + doneUrl + ".svg";
 	} else {
 		var iconUrl = "./imgs/icon_" + layerNumber + doneUrl + ".png";
 	}
@@ -501,7 +501,7 @@ for (let i = 0; i < typearray.length; i++) {
 			}
 			var doneUrl = markedFlag ? "_done" : ""
 			if (i == 0 || i == 1) {
-				var iconUrl = "./imgs/icon_" + i + doneUrl + ".png";
+				var iconUrl = "./imgs/icon_" + i + doneUrl + ".svg";
 			} else {
 				var iconUrl = "./imgs/icon_" + i + doneUrl + ".png";
 			}


### PR DESCRIPTION
http://m.dcinside.com/board/onshinproject/227133 댓글 참조
바람신/바위신 눈동자 아이콘 크기 비정상적으로 크던 부분 수정(40->24)
눈동자 맵에 표기되는 아이콘 png로드->svg로드로 변경
둘 다 개인용도로 수정해서 쓰던 부분인데 그대로 가지고 왔길래 수정 제안 넣어둠